### PR TITLE
Allow keyboard selection of ListBoxItem

### DIFF
--- a/eduVPN.Views/Pages/HomePage.xaml.cs
+++ b/eduVPN.Views/Pages/HomePage.xaml.cs
@@ -55,7 +55,10 @@ namespace eduVPN.Views.Pages
         {
             if (e.Key == Key.Enter ||
                 e.Key == Key.Space)
+            {
+                ((ListBoxItem)sender).IsSelected = true;
                 InstituteAccessServers_SelectItem(sender, e);
+            }
         }
 
         /// <summary>
@@ -84,7 +87,10 @@ namespace eduVPN.Views.Pages
         {
             if (e.Key == Key.Enter ||
                 e.Key == Key.Space)
+            {
+                ((ListBoxItem)sender).IsSelected = true;
                 SecureInternetServers_SelectItem(sender, e);
+            }
         }
 
         /// <summary>
@@ -113,7 +119,10 @@ namespace eduVPN.Views.Pages
         {
             if (e.Key == Key.Enter ||
                 e.Key == Key.Space)
+            {
+                ((ListBoxItem)sender).IsSelected = true;
                 OwnServers_SelectItem(sender, e);
+            }
         }
 
         #endregion

--- a/eduVPN.Views/Pages/SearchPage.xaml.cs
+++ b/eduVPN.Views/Pages/SearchPage.xaml.cs
@@ -100,7 +100,10 @@ namespace eduVPN.Views.Pages
         {
             if (e.Key == Key.Enter ||
                 e.Key == Key.Space)
+            {
+                ((ListBoxItem)sender).IsSelected = true;
                 InstituteAccessServers_SelectItem(sender, e);
+            }
         }
 
         /// <summary>
@@ -129,7 +132,10 @@ namespace eduVPN.Views.Pages
         {
             if (e.Key == Key.Enter ||
                 e.Key == Key.Space)
+            {
+                ((ListBoxItem)sender).IsSelected = true;
                 Organizations_SelectItem(sender, e);
+            }
         }
 
         /// <summary>
@@ -158,7 +164,10 @@ namespace eduVPN.Views.Pages
         {
             if (e.Key == Key.Enter ||
                 e.Key == Key.Space)
+            {
+                ((ListBoxItem)sender).IsSelected = true;
                 OwnServers_SelectItem(sender, e);
+            }
         }
 
         #endregion


### PR DESCRIPTION
At the momen it is not possible to select a ListBoxItem with return or space which prohibits usage of eduVPN without a pointing device. This is some sort of quick and somehow ugly fix.